### PR TITLE
Fix plant scanner and camera preview

### DIFF
--- a/app/src/main/java/com/example/mygemma3n/MainActivity.kt
+++ b/app/src/main/java/com/example/mygemma3n/MainActivity.kt
@@ -5,7 +5,6 @@ import android.Manifest
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
-import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.*
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
@@ -16,8 +15,13 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import com.example.mygemma3n.ui.theme.Gemma3nTheme
+import com.example.mygemma3n.feature.caption.LiveCaptionScreen
+import com.example.mygemma3n.feature.quiz.QuizScreen
+import com.example.mygemma3n.feature.plant.PlantScannerScreen
+import com.example.mygemma3n.feature.plant.PlantScannerViewModel
 import com.google.accompanist.permissions.ExperimentalPermissionsApi
 import com.google.accompanist.permissions.rememberMultiplePermissionsState
+import androidx.hilt.navigation.compose.hiltViewModel
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
@@ -81,13 +85,16 @@ fun Gemma3nNavigation(
             LiveCaptionScreen()
         }
         composable("quiz_generator") {
-            QuizGeneratorScreen()
+            QuizScreen()
         }
         composable("cbt_coach") {
             CBTCoachScreen()
         }
         composable("plant_scanner") {
-            PlantScannerScreen()
+            val vm: PlantScannerViewModel = hiltViewModel()
+            PlantScannerScreen(onScanClick = { bitmap ->
+                vm.analyzeImage(bitmap)
+            })
         }
         composable("crisis_handbook") {
             CrisisHandbookScreen()
@@ -157,31 +164,11 @@ fun HomeScreen(navController: androidx.navigation.NavHostController) {
 }
 
 @Composable
-fun LiveCaptionScreen() {
-    // Implement screen
-    Text("Live Caption Screen")
-}
-
-@Composable
-fun QuizGeneratorScreen() {
-    // Implement screen
-    Text("Quiz Generator Screen")
-}
-
-@Composable
 fun CBTCoachScreen() {
-    // Implement screen
     Text("CBT Coach Screen")
 }
 
 @Composable
-fun PlantScannerScreen() {
-    // Implement screen
-    Text("Plant Scanner Screen")
-}
-
-@Composable
 fun CrisisHandbookScreen() {
-    // Implement screen
     Text("Crisis Handbook Screen")
 }

--- a/app/src/main/java/com/example/mygemma3n/shared_ui/camera_preview.kt
+++ b/app/src/main/java/com/example/mygemma3n/shared_ui/camera_preview.kt
@@ -1,27 +1,22 @@
 package com.example.mygemma3n.shared_ui
 
-import android.view.ViewGroup
-import androidx.compose.runtime.*
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.viewinterop.AndroidView
-import androidx.camera.lifecycle.ProcessCameraProvider
-import androidx.camera.view.PreviewView
-import androidx.camera.core.Preview
-import androidx.camera.core.CameraSelector
 import androidx.camera.view.LifecycleCameraController
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.ui.platform.LocalContext
-import androidx.core.content.ContextCompat
-import androidx.lifecycle.compose.LocalLifecycleOwner
+import androidx.camera.view.PreviewView
 
 @Composable
-fun CameraPreview(modifier: Modifier = Modifier) {
-    val context = LocalContext.current
+fun CameraPreview(
+    controller: LifecycleCameraController,
+    modifier: Modifier = Modifier
+) {
     val lifecycleOwner = LocalLifecycleOwner.current
-    val cameraController = remember {
-        LifecycleCameraController(context).apply {
-            bindToLifecycle(lifecycleOwner)
-        }
+    LaunchedEffect(controller) {
+        controller.bindToLifecycle(lifecycleOwner)
     }
 
     AndroidView(
@@ -30,10 +25,10 @@ fun CameraPreview(modifier: Modifier = Modifier) {
             PreviewView(ctx).apply {
                 scaleType = PreviewView.ScaleType.FILL_START
                 implementationMode = PreviewView.ImplementationMode.COMPATIBLE
-                controller = cameraController
+                this.controller = controller
             }
         },
-        onRelease = { cameraController.unbind() }
+        onRelease = { controller.unbind() }
     )
 }
 

--- a/app/src/main/java/com/example/mygemma3n/shared_utilities/camera_utils.kt
+++ b/app/src/main/java/com/example/mygemma3n/shared_utilities/camera_utils.kt
@@ -1,0 +1,31 @@
+package com.example.mygemma3n.shared_utilities
+
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
+import android.graphics.ImageFormat
+import android.graphics.Rect
+import android.graphics.YuvImage
+import androidx.camera.core.ImageProxy
+import java.io.ByteArrayOutputStream
+
+fun ImageProxy.toBitmap(): Bitmap {
+    val yBuffer = planes[0].buffer
+    val uBuffer = planes[1].buffer
+    val vBuffer = planes[2].buffer
+
+    val ySize = yBuffer.remaining()
+    val uSize = uBuffer.remaining()
+    val vSize = vBuffer.remaining()
+
+    val nv21 = ByteArray(ySize + uSize + vSize)
+
+    yBuffer.get(nv21, 0, ySize)
+    vBuffer.get(nv21, ySize, vSize)
+    uBuffer.get(nv21, ySize + vSize, uSize)
+
+    val yuvImage = YuvImage(nv21, ImageFormat.NV21, width, height, null)
+    val out = ByteArrayOutputStream()
+    yuvImage.compressToJpeg(Rect(0, 0, width, height), 100, out)
+    val imageBytes = out.toByteArray()
+    return BitmapFactory.decodeByteArray(imageBytes, 0, imageBytes.size)
+}


### PR DESCRIPTION
## Summary
- wire navigation to actual feature screens
- add camera utilities and capture image in PlantScannerScreen
- refactor CameraPreview to accept controller
- keep placeholders for unimplemented screens

## Testing
- `sh ./gradlew test -q` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68631a8217488321b580126697d33cdd