### PR TITLE
Remove unused GemmaEngine extension

### DIFF
--- a/app/src/main/java/com/example/mygemma3n/feature/quiz/quiz_generator_viewmodel.kt
+++ b/app/src/main/java/com/example/mygemma3n/feature/quiz/quiz_generator_viewmodel.kt
@@ -415,19 +415,6 @@ class QuizGeneratorViewModel @Inject constructor(
         }
     }
 
-    // Add this at the bottom of QuizGeneratorViewModel.kt, outside the class
-    private suspend fun GemmaEngine.generateText(
-        prompt: String,
-        maxTokens: Int = 256,
-        temperature: Float = 0.7f,
-        modelConfig: GemmaModelManager.ModelConfig
-    ): Flow<String> {
-        val generationConfig = GemmaEngine.GenerationConfig(
-            maxNewTokens = maxTokens,
-            temperature = temperature
-        )
-        return generateText(prompt, generationConfig)
-    }
 
     private suspend fun generatePersonalizedFeedback(
         question: Question,


### PR DESCRIPTION
## Summary
- delete the private `GemmaEngine.generateText` helper in `quiz_generator_viewmodel.kt`
- rely on the shared `generateText` helper in `extenstions.kt`

## Testing
- `./gradlew build` *(fails: Unable to download Gradle wrapper due to network restrictions)*


------
https://chatgpt.com/codex/tasks/task_e_686327ca7d848321933fc7b942493aaa