### PR TITLE
Fix duplicate WorkManager provider

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -130,17 +130,6 @@
         </service>
 
 
-        <provider
-            android:name="androidx.startup.InitializationProvider"
-            android:authorities="${applicationId}.androidx-startup"
-            android:exported="false"
-            tools:node="merge">
-
-            <meta-data
-                android:name="androidx.work.WorkManagerInitializer"
-                tools:node="remove"/>
-        </provider>
-
 
     </application>
 


### PR DESCRIPTION
## Summary
- remove the second `InitializationProvider` from `AndroidManifest.xml`

## Testing
- `bash ./gradlew test` *(fails: Unable to download gradle)*

------
https://chatgpt.com/codex/tasks/task_e_68633bb824948321945a521c6e82de75