### PR TITLE
Add section on model assets

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,3 +117,7 @@ db.quizDao().unsynced().forEach { supabase.upsert(it) }
 return Result.success()
 }
 }
+
+## Model assets
+All `.tflite` shards must be placed in `app/src/main/assets/models/` with the exact filenames used by `checkModelAvailability`.
+The `.gitignore` file excludes this folder, so each developer needs to provide the files locally.


### PR DESCRIPTION
## Summary
- document where `.tflite` shards must be placed
- note that `.gitignore` excludes the model assets directory

## Testing
- `./gradlew test` *(fails: HTTP 403 when downloading Gradle)*

------
https://chatgpt.com/codex/tasks/task_e_6865cc46a54c83219284464ea1c5fb25