### PR TITLE
Switch plant scanner to Gemma 3n model

### DIFF
--- a/app/src/main/java/com/example/mygemma3n/data/model_download_service.kt
+++ b/app/src/main/java/com/example/mygemma3n/data/model_download_service.kt
@@ -551,32 +551,6 @@ class ModelDownloadManager @Inject constructor(
             .flowOn(Dispatchers.IO)
     }
 
-    // Example integration inside your ViewModel or service before inference or quiz generation
-
-    // Add this function in your ViewModel or service that handles quiz generation
-    suspend fun prepareAndGenerateQuiz(modelDownloadManager: ModelDownloadManager) {
-        val request = ModelDownloadManager.DownloadRequest(
-            url = "https://huggingface.co/google/gemma-3n-E4B-it-litert-preview/resolve/main/gemma-2b-it-fast.tflite",
-            name = "gemma-2b-it-fast",
-            type = "gemma-3n-2b"
-        )
-
-        val state = if (modelDownloadManager.isModelAvailable(request.name)) {
-            val info = modelDownloadManager.getAvailableModels().first { it.name == request.name }
-            ModelDownloadManager.DownloadState.Success(info.path, info.size)
-        } else {
-            var result: ModelDownloadManager.DownloadState = ModelDownloadManager.DownloadState.Idle
-            modelDownloadManager.downloadModel(request).collect { result = it }
-            result
-        }
-
-        if (state is ModelDownloadManager.DownloadState.Success) {
-            Timber.d("Model ready at ${state.modelPath}")
-            // Initialize model and proceed with inference/quiz
-        } else if (state is ModelDownloadManager.DownloadState.Error) {
-            Timber.e("Cannot proceed with quiz generation: ${state.message}")
-        }
-    }
 
 
     suspend fun ensureModelDownloaded(manager: ModelDownloadManager, request: ModelDownloadManager.DownloadRequest): ModelDownloadManager.DownloadState {

--- a/app/src/main/java/com/example/mygemma3n/feature/plant/plant_scanner_viewmodel.kt
+++ b/app/src/main/java/com/example/mygemma3n/feature/plant/plant_scanner_viewmodel.kt
@@ -33,7 +33,17 @@ class PlantScannerViewModel @Inject constructor(
     init {
         viewModelScope.launch {
             try {
-                val modelFile = File(context.filesDir, "models/gemma-2b-it-fast.tflite")
+                // Copy Gemma 3n model from assets if it hasn't been extracted yet
+                val modelFile = File(context.cacheDir, "models/gemma-3n-E2B-it-int4.task")
+                if (!modelFile.exists()) {
+                    modelFile.parentFile?.mkdirs()
+                    context.assets.open("models/gemma-3n-E2B-it-int4.task").use { input ->
+                        modelFile.outputStream().use { output ->
+                            input.copyTo(output)
+                        }
+                    }
+                }
+
                 gemmaEngine.initialize(
                     GemmaEngine.InferenceConfig(
                         modelPath = modelFile.absolutePath,


### PR DESCRIPTION
## Summary
- copy Gemma 3n model from assets into the cache when PlantScannerViewModel starts
- remove old Gemma 2b tflite reference

## Testing
- `./gradlew --version` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6867efcf4a7483218ae3441092063e6b