### PR TITLE
Add basic offline chat feature

### DIFF
--- a/app/src/main/java/com/example/mygemma3n/MainActivity.kt
+++ b/app/src/main/java/com/example/mygemma3n/MainActivity.kt
@@ -50,6 +50,7 @@ import com.example.mygemma3n.data.validateKey
 import com.example.mygemma3n.di.SpeechRecognitionServiceEntryPoint
 import com.example.mygemma3n.feature.caption.SpeechRecognitionService
 import com.example.mygemma3n.feature.cbt.CBTCoachScreen
+import com.example.mygemma3n.feature.chat.ChatScreen
 import com.example.mygemma3n.feature.crisis.CrisisHandbookScreen
 import com.google.android.play.core.assetpacks.AssetPackManagerFactory
 import com.google.android.play.core.assetpacks.AssetPackStateUpdateListener
@@ -344,6 +345,9 @@ fun Gemma3nNavigation(
         composable("cbt_coach") {
             CBTCoachScreen()
         }
+        composable("chat") {
+            ChatScreen()
+        }
         composable("plant_scanner") {
             PlantScannerScreen()
         }
@@ -480,6 +484,15 @@ fun HomeScreen(
             modifier = Modifier.fillMaxWidth()
         ) {
             Text("Voice CBT Coach")
+        }
+
+        Spacer(modifier = Modifier.height(8.dp))
+        Button(
+            onClick = { navController.navigate("chat") },
+            enabled = isGemmaInitialized,
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            Text("Chat")
         }
 
         Spacer(modifier = Modifier.height(8.dp))

--- a/app/src/main/java/com/example/mygemma3n/feature/chat/ChatMessage.kt
+++ b/app/src/main/java/com/example/mygemma3n/feature/chat/ChatMessage.kt
@@ -1,0 +1,17 @@
+package com.example.mygemma3n.feature.chat
+
+/** Simple chat message model */
+sealed class ChatMessage {
+    abstract val timestamp: Long
+    abstract val content: String
+
+    data class User(
+        override val content: String,
+        override val timestamp: Long = System.currentTimeMillis()
+    ) : ChatMessage()
+
+    data class AI(
+        override val content: String,
+        override val timestamp: Long = System.currentTimeMillis()
+    ) : ChatMessage()
+}

--- a/app/src/main/java/com/example/mygemma3n/feature/chat/ChatScreen.kt
+++ b/app/src/main/java/com/example/mygemma3n/feature/chat/ChatScreen.kt
@@ -1,0 +1,99 @@
+package com.example.mygemma3n.feature.chat
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.Send
+import androidx.compose.material.icons.filled.Mic
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ChatScreen(viewModel: ChatViewModel = hiltViewModel()) {
+    val state by viewModel.uiState.collectAsStateWithLifecycle()
+    var inputText by remember { mutableStateOf("") }
+
+    LaunchedEffect(state.userTypedInput) {
+        inputText = state.userTypedInput
+    }
+
+    Column(modifier = Modifier.fillMaxSize().padding(16.dp)) {
+        LazyColumn(
+            modifier = Modifier.weight(1f).padding(bottom = 8.dp),
+            reverseLayout = true
+        ) {
+            items(state.conversation.reversed()) { msg ->
+                ChatBubble(msg)
+            }
+        }
+
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.Bottom
+        ) {
+            OutlinedTextField(
+                value = inputText,
+                onValueChange = {
+                    if (!state.isRecording) {
+                        inputText = it
+                        viewModel.updateUserTypedInput(it)
+                    }
+                },
+                modifier = Modifier.weight(1f),
+                placeholder = { Text(if (state.isRecording) "Recording..." else "Type message") },
+                readOnly = state.isRecording
+            )
+
+            IconButton(onClick = {
+                if (state.isRecording) viewModel.stopRecording() else viewModel.startRecording()
+            }) {
+                if (state.isRecording) {
+                    CircularProgressIndicator(modifier = Modifier.size(24.dp), strokeWidth = 2.dp)
+                } else {
+                    Icon(Icons.Default.Mic, contentDescription = "Record")
+                }
+            }
+
+            IconButton(
+                onClick = { viewModel.sendMessage() },
+                enabled = inputText.isNotBlank() && !state.isRecording && !state.isLoading
+            ) {
+                if (state.isLoading) {
+                    CircularProgressIndicator(modifier = Modifier.size(24.dp), strokeWidth = 2.dp)
+                } else {
+                    Icon(Icons.AutoMirrored.Filled.Send, contentDescription = "Send")
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun ChatBubble(message: ChatMessage) {
+    val isUser = message is ChatMessage.User
+    Row(
+        modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp),
+        horizontalArrangement = if (isUser) Arrangement.End else Arrangement.Start
+    ) {
+        Card(
+            modifier = Modifier.widthIn(max = 280.dp).clip(MaterialTheme.shapes.medium),
+            colors = CardDefaults.cardColors(
+                containerColor = if (isUser) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.secondaryContainer
+            )
+        ) {
+            Text(
+                text = message.content,
+                modifier = Modifier.padding(12.dp),
+                color = if (isUser) MaterialTheme.colorScheme.onPrimary else MaterialTheme.colorScheme.onSecondaryContainer
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/example/mygemma3n/feature/chat/ChatViewModel.kt
+++ b/app/src/main/java/com/example/mygemma3n/feature/chat/ChatViewModel.kt
@@ -1,0 +1,129 @@
+package com.example.mygemma3n.feature.chat
+
+import android.content.Context
+import android.content.Intent
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.example.mygemma3n.data.UnifiedGemmaService
+import com.example.mygemma3n.feature.caption.SpeechRecognitionService
+import com.example.mygemma3n.service.AudioCaptureService
+import dagger.hilt.android.lifecycle.HiltViewModel
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.plus
+import javax.inject.Inject
+
+/** Chat view model handling basic conversation. */
+@HiltViewModel
+class ChatViewModel @Inject constructor(
+    @ApplicationContext private val context: Context,
+    private val gemmaService: UnifiedGemmaService,
+    private val speechService: SpeechRecognitionService
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(ChatState())
+    val uiState: StateFlow<ChatState> = _uiState.asStateFlow()
+
+    private var recordingJob: Job? = null
+    private val audioBuffer = mutableListOf<FloatArray>()
+
+    fun updateUserTypedInput(text: String) {
+        _uiState.update { it.copy(userTypedInput = text) }
+    }
+
+    fun startRecording() {
+        if (_uiState.value.isRecording) return
+
+        Intent(context, AudioCaptureService::class.java).apply {
+            action = AudioCaptureService.ACTION_START_CAPTURE
+            context.startService(this)
+        }
+        audioBuffer.clear()
+        _uiState.update { it.copy(userTypedInput = "", isRecording = true) }
+
+        recordingJob = AudioCaptureService.audioDataFlow
+            .filterNotNull()
+            .onEach { chunk -> audioBuffer.add(chunk.clone()) }
+            .launchIn(viewModelScope + Dispatchers.IO)
+    }
+
+    fun stopRecording() {
+        if (!_uiState.value.isRecording) return
+
+        Intent(context, AudioCaptureService::class.java).apply {
+            action = AudioCaptureService.ACTION_STOP_CAPTURE
+            context.startService(this)
+        }
+        recordingJob?.cancel()
+        recordingJob = null
+        _uiState.update { it.copy(isRecording = false) }
+
+        viewModelScope.launch {
+            val transcript = transcribeAudio()
+            if (transcript.isNotBlank()) {
+                _uiState.update { it.copy(userTypedInput = transcript) }
+            }
+        }
+    }
+
+    private suspend fun transcribeAudio(): String {
+        if (!speechService.isInitialized) return ""
+        val data = audioBuffer.flatten().toFloatArray()
+        val pcm = ByteArray(data.size * 2)
+        data.forEachIndexed { i, f ->
+            val v = (f.coerceIn(-1f, 1f) * 32767).toInt()
+            pcm[i * 2] = (v and 0xFF).toByte()
+            pcm[i * 2 + 1] = ((v shr 8) and 0xFF).toByte()
+        }
+        return speechService.transcribeAudioData(pcm, "en-US")
+    }
+
+    fun sendMessage() {
+        val text = _uiState.value.userTypedInput.trim()
+        if (text.isBlank()) return
+        viewModelScope.launch {
+            _uiState.update {
+                it.copy(
+                    isLoading = true,
+                    conversation = it.conversation + ChatMessage.User(text),
+                    userTypedInput = ""
+                )
+            }
+            try {
+                val reply = gemmaService.generateTextAsync(
+                    text,
+                    UnifiedGemmaService.GenerationConfig(
+                        maxTokens = 150,
+                        temperature = 0.7f
+                    )
+                )
+                _uiState.update {
+                    it.copy(
+                        conversation = it.conversation + ChatMessage.AI(reply)
+                    )
+                }
+            } catch (e: Exception) {
+                _uiState.update { it.copy(error = e.message) }
+            } finally {
+                _uiState.update { it.copy(isLoading = false) }
+            }
+        }
+    }
+}
+
+data class ChatState(
+    val conversation: List<ChatMessage> = emptyList(),
+    val userTypedInput: String = "",
+    val isRecording: Boolean = false,
+    val isLoading: Boolean = false,
+    val error: String? = null
+)


### PR DESCRIPTION
## Summary
- add new Chat feature with ChatMessage sealed class
- implement ChatViewModel for text generation and speech transcription
- create ChatScreen composable UI
- integrate Chat route and button into navigation

## Testing
- `./gradlew assembleDebug` *(fails: Unable to download Gradle)*

------
https://chatgpt.com/codex/tasks/task_e_687a793a99a48321b1638d97373c4361